### PR TITLE
add 2019 release calendar

### DIFF
--- a/maintainers/guide/release-management.md
+++ b/maintainers/guide/release-management.md
@@ -12,10 +12,54 @@ Rubrik Build releases currently happen bi-weekly.  The release process can be th
 
 * Feature Definition and Implementation
 * Code Review
-* Release 
+* Release
 
 ![Release Schedule](/maintainers/guide/img/release-schedule.png)
 
 ## Exceptions
 
-In the event of breakage or emergency bug fixes, the schedule may be altered to accomodate an immediate fix. That being said, all due diligence should still be met in regard to thorough code reviews and documentation updates. 
+In the event of breakage or emergency bug fixes, the schedule may be altered to accomodate an immediate fix. That being said, all due diligence should still be met in regard to thorough code reviews and documentation updates.
+
+## 2019 Release Calendar
+
+| Week         | Development | Review and Release |
+|--------------|-------------|--------------------|
+| April 8      | SDK         | Tooling            |
+| April 15     | Tooling     | SDK                |
+| April 22     | SDK         | Tooling            |
+| April 29     | Tooling     | SDK                |
+| May 6        | SDK         | Tooling            |
+| May 13       | Tooling     | SDK                |
+| May 20       | SDK         | Tooling            |
+| May 27       | Tooling     | SDK                |
+| June 3       | SDK         | Tooling            |
+| June 10      | Tooling     | SDK                |
+| June 17      | SDK         | Tooling            |
+| June 24      | Tooling     | SDK                |
+| July 1       | SDK         | Tooling            |
+| July 8       | Tooling     | SDK                |
+| July 15      | SDK         | Tooling            |
+| July 22      | Tooling     | SDK                |
+| July 29      | SDK         | Tooling            |
+| August 5     | Tooling     | SDK                |
+| August 12    | SDK         | Tooling            |
+| August 19    | Tooling     | SDK                |
+| August 26    | SDK         | Tooling            |
+| September 2  | Tooling     | SDK                |
+| September 9  | SDK         | Tooling            |
+| September 16 | Tooling     | SDK                |
+| September 23 | SDK         | Tooling            |
+| September 30 | Tooling     | SDK                |
+| October 7    | SDK         | Tooling            |
+| October 14   | Tooling     | SDK                |
+| October 21   | SDK         | Tooling            |
+| October 28   | Tooling     | SDK                |
+| November 4   | SDK         | Tooling            |
+| November 11  | Tooling     | SDK                |
+| November 18  | SDK         | Tooling            |
+| November 25  | Tooling     | SDK                |
+| December 2   | SDK         | Tooling            |
+| December 9   | Tooling     | SDK                |
+| December 16  | SDK         | Tooling            |
+| December 23  | Tooling     | SDK                |
+| December 30  | SDK         | Tooling            |


### PR DESCRIPTION
# Description

Breaks out the SDK and Tooling Dev/Release cycle into weekly sprints

## Motivation and Context

Better visibility into activities for the week

